### PR TITLE
Use python3.11

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install Ansible & Molecule
         run: |
             pip install ansible ansible-lint flake8


### PR DESCRIPTION
The test failed on the master branch this week and on the merged PR #24, even though it had previously passed on the PR itself. The issue was caused by a compatibility problem with the dependency version used by Python 3.12.  I downgraded the Python version to 3.11, which resolved the failure. This fixes the issue for now, but we should investigate further when we have time to identify which specific package is causing this behaviour.